### PR TITLE
Tweak to support Microsoft-style archives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ impl Header {
                     parse_number("GNU filename index", &buffer[1..16], 10)
                 ) as usize;
             let end =
-                match name_table[start..].iter().position(|&ch| ch == b'/') {
+                match name_table[start..].iter().position(|&ch| ch == b'/' || ch == b'\x00') {
                     Some(len) => start + len,
                     None => name_table.len(),
                 };


### PR DESCRIPTION
I happened to run into this looking at `msvcrt.lib` and friends, the name table consists of a bunch of null-terminated strings, rather than /-terminated as the code currently expects.

It now *appears* to work on these files, but I haven't tested too heavily. I'm also not sure how legit it is by MS licensing to keep a copy of one of their `.lib` apart from VS to test against.