### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ repository = "https://github.com/mdsteele/rust-ar"
 keywords = ["ar", "archive", "deb"]
 license = "MIT"
 readme = "README.md"
-
-[dependencies]
-byteorder = "1"


### PR DESCRIPTION
This removes the `byteorder`-dependency, making the crate dependency-free. The change raises the minimum Rust version to 1.32, the change is worth IMHO, though.