### PR TITLE
header: handle modtime -1 via special case

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -724,6 +724,16 @@ mod tests {
     }
 
     #[test]
+    fn read_archive_with_mtime_minus_one() {
+        let input = "\
+        !<arch>\n\
+        foo.txt         -1          501   20    100644  7         `\n\
+        foobar\n\n";
+        let mut archive = Archive::new(input.as_bytes());
+        archive.next_entry().unwrap().unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "Invalid owner ID field in entry header \
                                (\\\"foo   \\\")")]
     fn read_archive_with_invalid_uid() {

--- a/src/header.rs
+++ b/src/header.rs
@@ -173,7 +173,11 @@ impl Header {
             *variant = Variant::GNU;
             identifier.pop();
         }
-        let mtime = parse_number_permitting_minus_one("timestamp", &buffer[16..28], 10)?;
+        let mtime = parse_number_permitting_minus_one(
+            "timestamp",
+            &buffer[16..28],
+            10,
+        )?;
         let uid = if *variant == Variant::GNU {
             parse_number_permitting_empty("owner ID", &buffer[28..34], 10)?
         } else {

--- a/src/header.rs
+++ b/src/header.rs
@@ -173,7 +173,7 @@ impl Header {
             *variant = Variant::GNU;
             identifier.pop();
         }
-        let mtime = parse_number("timestamp", &buffer[16..28], 10)?;
+        let mtime = parse_number_permitting_minus_one("timestamp", &buffer[16..28], 10)?;
         let uid = if *variant == Variant::GNU {
             parse_number_permitting_empty("owner ID", &buffer[28..34], 10)?
         } else {
@@ -288,6 +288,31 @@ impl Header {
 fn parse_number(field_name: &str, bytes: &[u8], radix: u32) -> Result<u64> {
     if let Ok(string) = str::from_utf8(bytes) {
         if let Ok(value) = u64::from_str_radix(string.trim_end(), radix) {
+            return Ok(value);
+        }
+    }
+    let msg = format!(
+        "Invalid {} field in entry header ({:?})",
+        field_name,
+        String::from_utf8_lossy(bytes)
+    );
+    Err(Error::new(ErrorKind::InvalidData, msg))
+}
+
+/*
+ * Equivalent to parse_number() except for the case of "-1"
+ * as MS tools may emit for mtime.
+ */
+fn parse_number_permitting_minus_one(
+    field_name: &str,
+    bytes: &[u8],
+    radix: u32,
+) -> Result<u64> {
+    if let Ok(string) = str::from_utf8(bytes) {
+        let trimmed = string.trim_end();
+        if trimmed == "-1" {
+            return Ok(0);
+        } else if let Ok(value) = u64::from_str_radix(trimmed, radix) {
             return Ok(value);
         }
     }


### PR DESCRIPTION
Adds a routine to parse numbers with a special case of "-1", which is treated as 0, and used to parse the modification timestamp. This enables the library to parse some ar archives produced by Microsoft.

closes #26