### PR TITLE
Truncate UIDs and GIDs larger than 999999 (rev2)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -282,6 +282,27 @@ mod tests {
     }
 
     #[test]
+    fn build_common_archive_with_uid_gid_overflow() {
+        let mut builder = Builder::new(Vec::new());
+        let mut header1 = Header::new(b"foo.txt".to_vec(), 7);
+        header1.set_mtime(1487552916);
+        header1.set_uid(1234567);
+        header1.set_gid(7654321);
+        header1.set_mode(0o100644);
+        builder.append(&header1, "foobar\n".as_bytes()).unwrap();
+        let header2 = Header::new(b"baz.txt".to_vec(), 4);
+        builder.append(&header2, "baz\n".as_bytes()).unwrap();
+        let actual = builder.into_inner().unwrap();
+        let expected = "\
+        !<arch>\n\
+        foo.txt         1487552916  123456765432100644  7         `\n\
+        foobar\n\n\
+        baz.txt         0           0     0     0       4         `\n\
+        baz\n";
+        assert_eq!(str::from_utf8(&actual).unwrap(), expected);
+    }
+
+    #[test]
     fn build_bsd_archive_with_long_filenames() {
         let mut builder = Builder::new(Vec::new());
         let mut header1 = Header::new(b"short".to_vec(), 1);

--- a/src/header.rs
+++ b/src/header.rs
@@ -242,11 +242,11 @@ impl Header {
             let padded_length = self.identifier.len() + padding_length;
             writeln!(
                 writer,
-                "#1/{:<13}{:<12}{:<6}{:<6}{:<8o}{:<10}`",
+                "#1/{:<13}{:<12}{:<6.6}{:<6.6}{:<8o}{:<10}`",
                 padded_length,
                 self.mtime,
-                self.uid,
-                self.gid,
+                self.uid.to_string(),
+                self.gid.to_string(),
                 self.mode,
                 self.size + padded_length as u64
             )?;
@@ -257,8 +257,12 @@ impl Header {
             writer.write_all(&vec![b' '; 16 - self.identifier.len()])?;
             writeln!(
                 writer,
-                "{:<12}{:<6}{:<6}{:<8o}{:<10}`",
-                self.mtime, self.uid, self.gid, self.mode, self.size
+                "{:<12}{:<6.6}{:<6.6}{:<8o}{:<10}`",
+                self.mtime,
+                self.uid.to_string(),
+                self.gid.to_string(),
+                self.mode,
+                self.size
             )?;
         }
         Ok(())
@@ -282,8 +286,12 @@ impl Header {
         }
         writeln!(
             writer,
-            "{:<12}{:<6}{:<6}{:<8o}{:<10}`",
-            self.mtime, self.uid, self.gid, self.mode, self.size
+            "{:<12}{:<6.6}{:<6.6}{:<8o}{:<10}`",
+            self.mtime,
+            self.uid.to_string(),
+            self.gid.to_string(),
+            self.mode,
+            self.size
         )?;
         Ok(())
     }


### PR DESCRIPTION
Truncate UIDs and GIDs larger than 999999 so they do not overflow the 6-character field. (Second version. Replaces  https://github.com/mdsteele/rust-ar/pull/31 )