### PR TITLE
Trim 0b/0o/0x prefixes when parsing numbers.

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1169,4 +1169,21 @@ mod tests {
         let mut archive = Archive::new(std::io::Cursor::new(data));
         let _num_entries = archive.count_entries().unwrap();
     }
+
+    /// Test for entries with octal literal (0o) prefix in the mode field.
+    #[test]
+    fn read_archive_with_radix_prefixed_mode() {
+        let input = "\
+        !<arch>\n\
+        foo.txt/        1487552916  501   20    0o1006447         `\n\
+        foobar\n";
+        let mut archive = Archive::new(input.as_bytes());
+        {
+            let entry = archive.next_entry().unwrap().unwrap();
+            assert_eq!(entry.header().identifier(), "foo.txt".as_bytes());
+            assert_eq!(entry.header().mode(), 0o100644);
+            assert_eq!(entry.header().size(), 7);
+        }
+        assert!(archive.next_entry().is_none());
+    }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -308,6 +308,12 @@ fn cap_mode(mode: u32) -> u32 {
 
 fn parse_number(field_name: &str, bytes: &[u8], radix: u32) -> Result<u64> {
     if let Ok(string) = str::from_utf8(bytes) {
+        let string = match radix {
+            2 => string.trim_start_matches("0b"),
+            8 => string.trim_start_matches("0o"),
+            16 => string.trim_start_matches("0x"),
+            _ => string,
+        };
         if let Ok(value) = u64::from_str_radix(string.trim_end(), radix) {
             return Ok(value);
         }


### PR DESCRIPTION
In some rare cases, the file mode field in the headers of an ar package could have "0o" as prefix since the radix is 8. This change tries to trim radix prefixes when parsing numbers, as the current Rust `from_str_radix` API doesn't parse radix prefixes yet (refer to https://github.com/rust-lang/rfcs/issues/1098). 